### PR TITLE
Fix Windows path with normalization function

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -5,7 +5,7 @@ const nextBuild = require('next/dist/build').default
 const nextExport = require('next/dist/export').default
 
 // increase timeout since these are integration tests
-jest.setTimeout(10000)
+jest.setTimeout(20000)
 
 test('basic integration test', async () => {
   const basicFixture = path.join(__dirname, 'fixtures/basic')

--- a/loader.js
+++ b/loader.js
@@ -3,7 +3,7 @@ const matter = require('gray-matter')
 const glob = require('glob')
 const stringifyObject = require('stringify-object')
 const { getOptions } = require('loader-utils')
-const { extendFrontMatter } = require('./util')
+const { extendFrontMatter, normalizeToUnixPath  } = require('./util')
 
 // Loads markdown files with front matter and renders them into a layout.
 // Layout can be set using the `layout` key in the front matter, and will map
@@ -16,8 +16,8 @@ module.exports = async function mdxEnhancedLoader(src) {
   const { content, data } = matter(src)
 
   // Get file path relative to project root
-  const resourcePath = this.resourcePath
-    .replace(path.join(this.rootContext, 'pages'), '')
+  const resourcePath = normalizeToUnixPath(this.resourcePath)
+    .replace(normalizeToUnixPath(path.join(normalizeToUnixPath(this.rootContext)), 'pages'), '')
     .substring(1)
 
   // Checks if there's a layout, if there is, resolve the layout and wrap the content in it.
@@ -74,7 +74,7 @@ function processLayout(options, frontMatter, content, resourcePath) {
       }
 
       // Import the layout, export the layout-wrapped content, pass front matter into layout
-      return resolve(`import layout from '${layoutPath}'
+      return resolve(`import layout from '${normalizeToUnixPath(layoutPath)}'
 
 export default layout(${stringifyObject({
         ...frontMatter,

--- a/util.js
+++ b/util.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const crypto = require('crypto')
 
-module.exports.extendFrontMatter = async function extendFrontMatter({
+async function extendFrontMatter({
   content,
   phase,
   extendFm
@@ -11,17 +11,22 @@ module.exports.extendFrontMatter = async function extendFrontMatter({
 
   return extendFm.process(content)
 }
+module.exports.extendFrontMatter = extendFrontMatter
 
-module.exports.generateFrontmatterPath = function generateFrontmatterPath(
+function generateFrontmatterPath(
   filePath,
   root
 ) {
-  return path.join(
+  const filePathNormalized = normalizeToUnixPath(filePath)
+  const dirnameNormalized = normalizeToUnixPath(__dirname)
+  
+  return normalizeToUnixPath(path.join(
     root,
     '.mdx-data',
-    `${md5(filePath.replace(__dirname, ''))}.json`
-  )
+    `${md5(filePathNormalized.replace(dirnameNormalized, ''))}.json`
+  ))
 }
+module.exports.generateFrontmatterPath = generateFrontmatterPath
 
 // md5 hash a string
 function md5(str) {
@@ -30,3 +35,8 @@ function md5(str) {
     .update(str)
     .digest('hex')
 }
+
+function normalizeToUnixPath(str) {
+  return str.replace(/\\/g, '/')
+}
+module.exports.normalizeToUnixPath = normalizeToUnixPath 


### PR DESCRIPTION
An all day pair programming endeavor with the great @JMFURY - windows problem are now GONE!
🎉

The issue here was that while windows paths (that use `\` instead of `/`) work perfectly well for filesystem operations, node require/imports expect unix-style paths, and when there is a windows-style path, the `\` character is treated as an escape within a string. So for example:

```js
import foo from '.\bar'
```

This would be treated as an escape character within a string, rather than a path separator, since that's exactly what it is to a javascript interpreter. As such, we need to normalize any paths that are being injected into files to be unix-style. This was a particularly difficult task given that there's a lot of path work in this plugin, and some paths are used both to run filesystem operations and are embedded within files. But we tracked down all the instances where it needed to be corrected, and it is now done!