### PR TITLE
Improve yaml error handling

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -15,7 +15,7 @@ module.exports = async function mdxEnhancedLoader(src) {
   // Parse the front matter
   let content, data
   try {
-    const res = matter(src)
+    const res = matter(src, { safeLoad: true, filename: this.resourcePath })
     content = res.content
     data = res.data
   } catch (err) {

--- a/loader.js
+++ b/loader.js
@@ -13,7 +13,14 @@ module.exports = async function mdxEnhancedLoader(src) {
   const options = getOptions(this)
 
   // Parse the front matter
-  const { content, data } = matter(src)
+  let content, data
+  try {
+    const res = matter(src)
+    content = res.content
+    data = res.data
+  } catch (err) {
+    callback(err)
+  }
 
   // Get file path relative to project root
   const resourcePath = normalizeToUnixPath(this.resourcePath)


### PR DESCRIPTION
Previously, yaml errors within the loader would silently crash, and errors within the primary plugin wouldn't show the file that they came from or an accurate trace. Adding some extra options to the front matter parse and some extra error handling takes care of this.