### PR TITLE
[#19] support .md and other file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The default mdx nextjs plugin takes care of point number one, but nothing else. 
 mdxEnhanced({
   layoutPath: 'somePath/otherPath',
   defaultLayout: true,
+  fileExtensions: ['mdx'],
   remarkPlugins: [],
   rehypePlugins: [],
   extendFrontMatter: {
@@ -65,6 +66,12 @@ Directory used to resolve page layout when `layout` key present in front matter.
 > `boolean` | optional
 
 Set value to `true` to treat `index.[extension]` within `layoutPath` as the default layout for any `.mdx` file that a layout has not been specified for.
+
+### fileExtensions
+
+> `array` | optional | **default: `['mdx']`**
+
+Array of file extensions that should be processed as MDX pages.
 
 ### remarkPlugins
 

--- a/index.js
+++ b/index.js
@@ -8,16 +8,19 @@ const debug = require('debug')('next-mdx-enhanced')
 
 module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
   if (!pluginOptions.layoutPath) pluginOptions.layoutPath = 'layouts'
+  if (!pluginOptions.fileExtensions) pluginOptions.fileExtensions = ['mdx']
 
   // Set default pageExtensions if not set already
   if (!nextConfig.pageExtensions) {
     nextConfig.pageExtensions = ['jsx', 'js']
   }
 
-  // Add mdx as a page extension so that mdx files are compiled as pages
-  if (nextConfig.pageExtensions.indexOf('mdx') === -1) {
-    nextConfig.pageExtensions.unshift('mdx')
-  }
+  // Add supported file extensions as page extensions so that mdx files are compiled as pages
+  pluginOptions.fileExtensions.forEach(ext => {
+      if (nextConfig.pageExtensions.indexOf(ext) === -1) {
+        nextConfig.pageExtensions.unshift(ext)
+      }
+  })
 
   // Set default 'phase' for extendFrontMatter option
   if (
@@ -31,7 +34,7 @@ module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
     webpack(config, options) {
       // Add mdx webpack loader stack
       config.module.rules.push({
-        test: /\.mdx?$/,
+        test: new RegExp(`\\.(${ pluginOptions.fileExtensions.join('|') })$`),
         use: [
           options.defaultLoaders.babel,
           {
@@ -70,7 +73,7 @@ module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
             return extractFrontMatter(pluginOptions, files, compilation.context)
           },
           files: {
-            pattern: '**/*.mdx',
+            pattern: `**/*.{${ pluginOptions.fileExtensions.join(',') }}`,
             options: { cwd: config.context },
             addFilesAsDependencies: true
           }


### PR DESCRIPTION
Fixes #19 

The plugin was inconsistent in its handling: it would render .md pages just fine (line 34), but wouldn't cache frontmatter for them or automatically add them to nextConfig.pageExtensions.

I went with default-to-both because that fit what I was working on, but I'd be fine with default-to-only-mdx if that fits the project better. 