### PR TITLE
Fix pageExtensions in config to support typescript

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,9 @@ module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
 
   // Set default pageExtensions if not set already
   if (!nextConfig.pageExtensions) {
-    nextConfig.pageExtensions = ['jsx', 'js']
+    // This extension list should be kept in sync with the NextJS default:
+    // https://github.com/zeit/next.js/blob/d9abbaded1a443056a5cee68d6bbda6f42057dae/packages/next-server/server/config.ts#L19
+    nextConfig.pageExtensions = ['tsx', 'ts', 'jsx', 'js']
   }
 
   // Add mdx as a page extension so that mdx files are compiled as pages


### PR DESCRIPTION
NextJS has made changes to the default `pageExtensions` to support Typescript: https://github.com/zeit/next.js/pull/7110/files.  This change updates the `pageExtensions` used in this project to match, which means that pipelines using this plugin will be able to use Typescript pages.