### PR TITLE
Add a `scan` option to allow for Layout customization

### DIFF
--- a/__tests__/fixtures/scan-mdx-content/components/Snargles.jsx
+++ b/__tests__/fixtures/scan-mdx-content/components/Snargles.jsx
@@ -1,0 +1,3 @@
+export default function Snargles() {
+  return <div>FooBar</div>
+}

--- a/__tests__/fixtures/scan-mdx-content/layouts/docs-page.jsx
+++ b/__tests__/fixtures/scan-mdx-content/layouts/docs-page.jsx
@@ -1,0 +1,30 @@
+import { frontMatter as introData } from '../pages/docs/intro.mdx'
+import { frontMatter as advancedData } from '../pages/docs/advanced.mdx'
+export default frontMatter => {
+  const __scans = frontMatter.__scans
+  return function docsPageLayout({ children }) {
+    return (
+      <>
+        {/* Similar to adding a script to document <head/> we load a font stylesheet here vs. running arbitrary JS */}
+        {__scans.hasSnargles && (
+          <link
+            href="https://fonts.googleapis.com/css?family=Press+Start+2P"
+            rel="stylesheet"
+          />
+        )}
+
+        <h1 style={{ fontFamily: "'Press Start 2P'" }}>{frontMatter.title}</h1>
+        <h2 style={{ fontFamily: "'Press Start 2P'" }}>
+          Should render in 8-bit font because...
+        </h2>
+        {__scans.hasSnargles && <h1>We found snargles</h1>}
+
+        {__scans.snarglesName && <h1>{__scans.snarglesName}</h1>}
+        <p>
+          Other docs: {introData.title}, {advancedData.title}
+        </p>
+        {children}
+      </>
+    )
+  }
+}

--- a/__tests__/fixtures/scan-mdx-content/next.config.js
+++ b/__tests__/fixtures/scan-mdx-content/next.config.js
@@ -1,0 +1,13 @@
+const withMdxEnhanced = require('../../..')
+
+module.exports = withMdxEnhanced({
+  scan: {
+    hasSnargles: {
+      pattern: /<Snargles.*.*\/>/
+    },
+    snarglesName: {
+      pattern: /<Snargles.*name=['"](.*)['"].*\/>/,
+      transform: arr => arr[1] // An optional callback function that transforms the result of the match operation
+    }
+  }
+})()

--- a/__tests__/fixtures/scan-mdx-content/pages/docs/advanced.mdx
+++ b/__tests__/fixtures/scan-mdx-content/pages/docs/advanced.mdx
@@ -1,0 +1,10 @@
+---
+layout: 'docs-page'
+title: 'Advanced Docs'
+---
+
+import Snargles from '../../components/Snargles'
+
+This is some _really_ **advanced** docs content!
+
+<Snargles name="Nigel Thornberry" />

--- a/__tests__/fixtures/scan-mdx-content/pages/docs/intro.mdx
+++ b/__tests__/fixtures/scan-mdx-content/pages/docs/intro.mdx
@@ -1,0 +1,10 @@
+---
+layout: 'docs-page'
+title: 'Intro Docs'
+---
+
+import Snargles from '../../components/Snargles'
+
+Here's some _introductory_ docs content
+
+<Snargles />

--- a/__tests__/fixtures/scan-mdx-content/pages/index.jsx
+++ b/__tests__/fixtures/scan-mdx-content/pages/index.jsx
@@ -1,0 +1,14 @@
+import { frontMatter as introData } from './docs/intro.mdx'
+import { frontMatter as advancedData } from './docs/advanced.mdx'
+
+export default () => {
+  return (
+    <>
+      <p>Hello world</p>
+      <ul>
+        <li>{introData.title}</li>
+        <li>{advancedData.title}</li>
+      </ul>
+    </>
+  )
+}

--- a/__tests__/fixtures/scan-mdx-content/use-cases.md
+++ b/__tests__/fixtures/scan-mdx-content/use-cases.md
@@ -1,0 +1,53 @@
+# Head Tag Customization
+
+Let's assume you want to support some external content feature such as a dynamic social media feed, photo or video embed, or some other interesting vendor-provided feature that would usually require
+
+1. A bit of HTML markup
+2. A vendor-provided script
+
+A good place for this script would likely be within the HTML document `<head>` or near the closing `</body>` - both of which will need to be handled by your `Layout` component if you're building an `MDX`-driven page.
+
+`MDX` Page
+
+```mdx
+---
+layout: 'docs-page'
+title: 'Intro Docs'
+---
+
+import EmbeddedContentFeed from '../../components/EmbeddedContentFeed'
+
+Here's some _introductory_ docs content
+
+<EmbeddedContentFeed /> // outputs <div data-id="foo" data-vendor-xyz-property="bar"></div>
+```
+
+`next.config.js`
+
+```js
+module.exports = withMdxEnhanced({
+  scan: {
+    hasEmbeddedContentFeed: {
+      pattern: /<EmbeddedContentFeed.*\/>/
+    }
+  }
+})()
+```
+
+The plugin returns `__scans : { hasEmbeddedContentFeed: ['/<EmbeddedContentFeed \/>/'] }`
+
+This can be used in the `Layout` component to conditionally load the script
+
+```jsx
+export default plugIn => {
+  const __scans = plugIn.__scans
+  return function docsPageLayout({ children }) {
+    return (
+   <>
+      <Head>
+        {__scans.hasEmbeddedContentFeed && (
+          <script  src="//vendor.com/embed.js" ></script>
+        )}
+     </Head>
+//....
+```

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -58,6 +58,18 @@ test('options.fileExtensions', async () => {
   expectContentMatch(outPath, 'index.html', /<p>mdx: <span>\.mdx<\/span><\/p>/)
 })
 
+test('options.scan', async () => {
+  const scansFixture = path.join(__dirname, 'fixtures/scan-mdx-content')
+  const outPath = await compileNextjs(scansFixture)
+  expectContentMatch(outPath, 'docs/intro.html', /css\?family=Press\+Start\+2P/)
+  expectContentMatch(outPath, 'docs/intro.html', /<h1>We found snargles<\/h1>/)
+  expectContentMatch(
+    outPath,
+    'docs/advanced.html',
+    /<h1>Nigel Thornberry<\/h1>/
+  )
+})
+
 // Remove artifacts
 afterAll(() => {
   return Promise.all([


### PR DESCRIPTION
### Status
Final stages of review

### How It Works
#### Sample `next.config.js` entry: 
```js
// in next.config.js
withMdxEnhanced({
  scan: {
someImportantKey : {
    pattern: /<SomeComponent.*name=['"](.*)['"].*\/>/,
    transform: arr => arr // does nothing unless used to pluck value
  }
})
```
If an MDX page uses `<SomeComponent />`

```js
---
layout: 'docs-page'
title: 'Advanced Docs'
---

import SomeComponent from '../../components/SomeComponent'

This is some _really_ **advanced** docs content!

<SomeComponent name="Find this text" />
<SomeComponent name="Find this text also" />
```
This will produce an `Array` of matches. 

```js
__scans : { someImportantKey : ['Find this text', 'Find this text also'] } 
```
It is then up to the developer to consume these values in the `Layout` with `__scans` that is passed in as a parameter. This is where some interesting use cases become possible!

### `<script>` Use Case: Moved to [`use-cases.md`](https://github.com/hashicorp/next-mdx-enhanced/blob/902958cc15f1cd776d04490639e465271e2a7033/__tests__/fixtures/scan-mdx-content/use-cases.md) 


