### PR TITLE
Small readme fix in import-glob-array example

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,13 @@ export default () => {
   return (<>
     <h1>Docs Index<h1>
     <ul>
-      {frontMatter.map(page => {
-        <li><Link href={formatPath(page.__resourcePath)}><a>{page.title}</a></Link></li>
-      })}
+      {frontMatter.map(page => (
+        <li key={page.__resourcePath}>
+          <Link href={formatPath(page.__resourcePath)}>
+            <a>{page.title}</a>
+          </Link>
+        </li>
+      ))}
     </ul>
   </>)
 }


### PR DESCRIPTION
Map function with curly-braces and without return statements doesn't render any links. Replace the curly-braces with sound one and add a key to the mapped list items.