### PR TITLE
Ensure tsx layout files will be loaded

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -112,7 +112,7 @@ function processLayout(options, frontMatter, content, resourcePath, scans) {
       }
 
       // Import the layout, export the layout-wrapped content, pass front matter into layout
-      return resolve(`import layout from '${normalizeToUnixPath(layoutPath)}'
+      return resolve(`import layout from '${normalizeToUnixPath(matches[0])}'
       
 export default layout(${stringifyObject({
         ...frontMatter,


### PR DESCRIPTION
TL;DR I updated the loader to have explicit imports which fixes loading in the default layout

I'd come across an issue my default layout file (`index.tsx`) wasn't being loaded. I tried changing every extension config that I could (from next's `pageExtensions` to webpack's `resolve.extensions`) but I couldn't get it to work. 

Here's my next config:
```
const withMDX = require("next-mdx-enhanced")({
  defaultLayout: true
});

module.exports = withMDX({});
```

And this was the error
```
Module not found: Can't resolve '~/next-site/layouts/index' in '~/next-site/pages/blog'

> Build error occurred
Error: > Build failed because of webpack errors
    at build (~/next-site/node_modules/next/dist/build/index.js:9:900)
```

I have tsx files in my project that are otherwise working. Updating the import statement to point to the specific matched file fixes the issue though.