### PR TITLE
Include frontMatter in extendFrontMatter process

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ module.exports = withMdxEnhanced({
   remarkPlugins: [],
   rehypePlugins: [],
   extendFrontMatter: {
-    process: mdxContent => {},
+    process: (mdxContent, frontMatter) => {},
     phase: 'prebuild|loader|both'
   }
 })(/* your normal nextjs config */)
@@ -103,7 +103,7 @@ Array of [rehype plugins](https://mdxjs.com/advanced/plugins#using-remark-and-re
 
 | Property  | Type       | Description                                                                                                                                                           |
 | --------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `process` | `function` | A hook function whose return value will be appended to the processed front matter. This function is given access to the source `.mdx` content as the first parameter. |
+| `process` | `function` | A hook function whose return value will be appended to the processed front matter. This function is given access to the source `.mdx` content as the first parameter and the processed front matter as the second parameter. |
 | `phase`   | `string`   | Used to specify when to run the `process` function. Eligible values are `prebuild`, `loader`, `both`. Defaults to `both` if not specified.                            |
 
 ### scan

--- a/__tests__/fixtures/extend-frontmatter/layouts/docs-page.jsx
+++ b/__tests__/fixtures/extend-frontmatter/layouts/docs-page.jsx
@@ -8,6 +8,9 @@ export default frontMatter => {
         <p>LAYOUT TEMPLATE</p>
         <h1>{frontMatter.title}</h1>
         <p>
+          All frontMatter: {JSON.stringify(frontMatter)}
+        </p>
+        <p>
           Other docs: {introData.title}, {advancedData.title}
         </p>
         {children}

--- a/__tests__/fixtures/extend-frontmatter/next.config.async.js
+++ b/__tests__/fixtures/extend-frontmatter/next.config.async.js
@@ -2,13 +2,15 @@ const withMdxEnhanced = require('../../..')
 
 module.exports = withMdxEnhanced({
   extendFrontMatter: {
-    process: mdxContent => {
+    process: (mdxContent, frontMatter) => {
       return new Promise(resolve =>
         setTimeout(() => {
-          return resolve({ __async: 'this data is async' })
+          return resolve({
+            __async: 'this data is async',
+            reversePath: frontMatter.__resourcePath.split('').reverse().join('')
+          })
         }, 50)
       )
     },
-    phase: 'prebuild',
   },
 })()

--- a/__tests__/fixtures/extend-frontmatter/next.config.js
+++ b/__tests__/fixtures/extend-frontmatter/next.config.js
@@ -2,9 +2,10 @@ const withMdxEnhanced = require('../../..')
 
 module.exports = withMdxEnhanced({
   extendFrontMatter: {
-    process: mdxContent => {
+    process: (mdxContent, frontMatter) => {
       return {
         __outline: 'outline stuff',
+        reversePath: frontMatter.__resourcePath.split('').reverse().join('')
       }
     },
   },

--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -43,12 +43,14 @@ describe('options.extendFrontMatter', () => {
     const extendFmFixture = path.join(__dirname, 'fixtures/extend-frontmatter')
     const outPath = await compileNextjs(extendFmFixture)
     expectContentMatch(outPath, 'index.html', /Hello world/)
+    expectContentMatch(outPath, 'docs/intro.html', /ortni\/scod/)
   })
 
   it('should work with an async process fn', async () => {
     const extendFmFixture = path.join(__dirname, 'fixtures/extend-frontmatter')
     const outPath = await compileNextjs(extendFmFixture, 'next.config.async.js')
     expectContentMatch(outPath, 'index.html', /Hello world/)
+    expectContentMatch(outPath, 'docs/intro.html', /ortni\/scod/)
   })
 })
 

--- a/index.js
+++ b/index.js
@@ -105,23 +105,29 @@ async function extractFrontMatter(pluginOptions, files, root) {
   debug('start: frontmatter extensions')
   const frontMatter = await Promise.all(
     fileContents.map(async (content, idx) => {
-      const extendedFm = await extendFrontMatter({
-        content,
-        phase: 'prebuild',
-        extendFm: pluginOptions.extendFrontMatter
-      })
+      const __resourcePath = files[idx]
+        .replace(path.join(root, 'pages'), '')
+        .substring(1)
 
       const { data } = matter(content, {
         safeLoad: true,
         filename: files[idx]
       })
 
+      const extendedFm = await extendFrontMatter({
+        content,
+        frontMatter: {
+          ...data,
+          __resourcePath
+        },
+        phase: 'prebuild',
+        extendFm: pluginOptions.extendFrontMatter
+      })
+
       return {
         ...data,
         ...extendedFm,
-        __resourcePath: files[idx]
-          .replace(path.join(root, 'pages'), '')
-          .substring(1)
+        __resourcePath
       }
     })
   ).catch(console.error)

--- a/loader.js
+++ b/loader.js
@@ -88,6 +88,11 @@ async function processLayout(options, frontMatter, content, resourcePath, scans)
 
   const extendedFm = await extendFrontMatter({
     content,
+    frontMatter: {
+      ...frontMatter,
+      __resourcePath: resourcePath,
+      __scans: scans
+    },
     phase: 'loader',
     extendFm: pluginOpts.extendFrontMatter
   })

--- a/util.js
+++ b/util.js
@@ -3,13 +3,14 @@ const crypto = require('crypto')
 
 async function extendFrontMatter({
   content,
+  frontMatter,
   phase,
   extendFm
 } = {}) {
   if (!extendFm || !extendFm.process) return {}
   if (extendFm.phase !== 'both' && extendFm.phase !== phase) return {}
 
-  return extendFm.process(content)
+  return extendFm.process(content, frontMatter)
 }
 module.exports.extendFrontMatter = extendFrontMatter
 


### PR DESCRIPTION
This adds the ability to inspect the existing front matter (including the processed additions) from the extendFrontMatter `process` function.

This can be useful if you'd like to pre-compute some front matter that's derived from the existing front matter.