### PR TITLE
Fix tests by promisifying glob

### DIFF
--- a/__tests__/integration.js
+++ b/__tests__/integration.js
@@ -6,7 +6,7 @@ const nextExport = require('next/dist/export').default
 const glob = require('glob')
 
 // increase timeout since these are integration tests
-jest.setTimeout(20000)
+jest.setTimeout(200000)
 
 test('basic integration test', async () => {
   const basicFixture = path.join(__dirname, 'fixtures/basic')


### PR DESCRIPTION
The tests were failing on master since 4a234855ae419a746325702efea029fffcc63271 replace a `resolve()` with a `return` inside a callback to glob. This replaces the call to glob with a promisified version so that the `return` is in the top level function.

I also bumped the test timeout to 200s since I was getting pretty frequent test timeouts