### PR TITLE
Export all named exports from layout

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -120,6 +120,7 @@ async function processLayout(options, frontMatter, content, resourcePath, scans)
   // Import the layout, export the layout-wrapped content, pass front matter into layout
   return `import layout from '${normalizeToUnixPath(layoutPath)}'
 
+export * from '${normalizeToUnixPath(layoutPath)}'
 export default layout(${stringifyObject({
     ...frontMatter,
     ...extendedFm,


### PR DESCRIPTION
There's an [RFC](https://github.com/zeit/next.js/issues/9524) in next (that's released in 9.X as unstable) that improves static generation. The api for this is exposed by having a top level export on the nextjs page

```javascript
// pages/index.js

// getStaticProps is only called server-side
export async function getStaticProps(context) {
  return {
    // Unlike `getInitialProps` the props are returned under a props key
    // The reasoning behind this is that there's potentially more options
    // that will be introduced in the future.
    // For example to allow you to further control behavior per-page.
    props: {}
  };
}
```

This is unliked the previous API which was attached to the default export. In order to take advantage of this API with layouts, we need to forward all named exports from the layout. This will allow a layout file to provide `getStaticProps`, `getStaticPaths`, and `getServerProps` to hook into the corresponding optimizations. 