### PR TITLE
[WIP] Allow extending frontmatter from layout file

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -119,13 +119,27 @@ async function processLayout(options, frontMatter, content, resourcePath, scans)
 
   // Import the layout, export the layout-wrapped content, pass front matter into layout
   return `import layout from '${normalizeToUnixPath(layoutPath)}'
+import * as imports from '${normalizeToUnixPath(layoutPath)}'
 
-export default layout(${stringifyObject({
+let frontMatter = ${stringifyObject({
     ...frontMatter,
     ...extendedFm,
     ...{ __resourcePath: resourcePath },
     ...{ __scans: scans }
-  })})
+  })}
+
+if (typeof imports.extendFrontMatter === "function") {
+  frontMatter = {
+    ...frontMatter,
+    ...imports.extendFrontMatter(frontMatter),
+    ...${stringifyObject({
+      ...{ __resourcePath: resourcePath },
+      ...{ __scans: scans }
+    })}
+  }
+}
+
+export default layout(frontMatter)
 
 ${content}
 `


### PR DESCRIPTION
I'm working on a documentation generator using next for this site that I'm building. With some of my layouts (like for docs), I want to add some defaults to the frontmatter if it's not already present. In my docs, for example, I try to infer what section of the docs it should be listed in based on what directory it's in. 

Here's my [really rough example](https://github.com/graphlog/graphlog-docs/blob/fb74e28705819eb17eb1994767f4048f90afa62a/next.config.js#L8-L32)

What's already provided by `next-mdx-enhanced` is sufficient for this practice... my only issue is where the logical grouping is placed. If I want to contextually modify the frontmatter of docs files, I'd rather do that directly from the `docs` layout. 

This PR roughly gives the ability to export a `extendFrontMatter` method from the layout itself. Currently, unlike the main `extendFrontMatter` method, this acts directly as `process`, but _doesn't_ get `content`. 

---

I'm going to make a patch package update to my project with this PR and refactor things to show what the final version would look like. 