### PR TITLE
Enable overriding of layout in extendFrontMatter

### DIFF
--- a/__tests__/fixtures/extend-frontmatter/next.config.async.js
+++ b/__tests__/fixtures/extend-frontmatter/next.config.async.js
@@ -7,6 +7,7 @@ module.exports = withMdxEnhanced({
         setTimeout(() => {
           return resolve({
             __async: 'this data is async',
+            layout: 'docs-page',
             reversePath: frontMatter.__resourcePath.split('').reverse().join('')
           })
         }, 50)

--- a/__tests__/fixtures/extend-frontmatter/next.config.js
+++ b/__tests__/fixtures/extend-frontmatter/next.config.js
@@ -5,6 +5,7 @@ module.exports = withMdxEnhanced({
     process: (mdxContent, frontMatter) => {
       return {
         __outline: 'outline stuff',
+        layout: 'docs-page',
         reversePath: frontMatter.__resourcePath.split('').reverse().join('')
       }
     },

--- a/__tests__/fixtures/extend-frontmatter/pages/docs/advanced.mdx
+++ b/__tests__/fixtures/extend-frontmatter/pages/docs/advanced.mdx
@@ -1,5 +1,4 @@
 ---
-layout: 'docs-page'
 title: 'Advanced Docs'
 ---
 


### PR DESCRIPTION
This reorganizes the order of determining the layout vs processing `extendFrontMatter` in order to allow `layout` to be overridable in the `loader` pass. 

## Context

I'm building a documentation generator. In this generator, I want to automatically be able to provide a layout based on the name of a file. 

Here's a rough example:

```
pages
├─ landing.mdx
├─ docs
│  ├─ getting-started.mdx
│  └─ contributing.mdx
└─ layouts
   ├─ index.tsx
   └─ docs.tsx
```

In this setup, I want to be able to automatically assign any `.mdx` file in the `docs` directory with the `docs` layout. The default layout will apply in other cases. 

My `next.js` config would look something like this:

```javascript
withMDXEnhanced({
  defaultLayout: true,
  extendFrontMatter: {
    process: (_, { __resourcePath, layout }) => {
      if (!layout) {
        const defaultLayout = __resourcePath.split("/")[0];
        if (
          fs.existsSync(
            path.join(process.cwd(), `layouts/${defaultLayout}.tsx`)
          )
        ) {
          return {
            layout: defaultLayout
          };
        }
      }
    },
    phase: "loader"
  }
})
```