### PR TITLE
Restrict frontmatter extraction to pages directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,8 +73,8 @@ module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
           files: {
             pattern:
               pluginOptions.fileExtensions.length > 1
-                ? `**/*.{${pluginOptions.fileExtensions.join(',')}}`
-                : `**/*.${pluginOptions.fileExtensions[0]}`,
+                ? `pages/**/*.{${pluginOptions.fileExtensions.join(',')}}`
+                : `pages/**/*.${pluginOptions.fileExtensions[0]}`,
             options: { cwd: config.context },
             addFilesAsDependencies: true,
           },


### PR DESCRIPTION
This change sets the path for the Webpack Plugin so that it doesn't walk over all subdirectories, but rather restricts itself to the pages directory. This in turn insures that the frontmatter extraction work will not run over every mdx (or md if specified in options) file in a given Next project (including those in node_modules), reducing compile time and reducing the perf/stability impact of using the `extendFrontMatter` option
Fixes #67 