### PR TITLE
Add missing curly brace to example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,11 +292,11 @@ withMdxEnhanced({
     {
       someImportantKey: {
         pattern: /<SomeComponent.*name=['"](.*)['"].*\/>/,
-        transform: arr => arr[1] // Optionally get a specific value back via a function;
-				// if `transform` is omitted, any and all matches will be returned in an array
-			}
-    }
-  ]
+        transform: (arr) => arr[1], // Optionally get a specific value back via a function;
+        // if `transform` is omitted, any and all matches will be returned in an array
+      },
+    },
+  ],
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -293,7 +293,8 @@ withMdxEnhanced({
       someImportantKey: {
         pattern: /<SomeComponent.*name=['"](.*)['"].*\/>/,
         transform: arr => arr[1] // Optionally get a specific value back via a function;
-        // if `transform` is omitted, any and all matches will be returned in an array
+				// if `transform` is omitted, any and all matches will be returned in an array
+			}
     }
   ]
 })


### PR DESCRIPTION
Hi, I noticed there was a missing curly brace in the docs.