### PR TITLE
Add note in readme where hooks should go in layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ The template, defined in `layouts/docs-page.jsx`, looks like the following:
 ```jsx
 export default function Layout(frontMatter) {
   return ({ children: content }) => {
+    // React hooks, for example `useState` or `useEffect`, go here.
     return (
       <div>
         <h1>{frontMatter.title}</h1>


### PR DESCRIPTION
I spent a bit of time a bit confused because I was putting hooks in the parent function.

What do you think about this simple note as a solution to prevent someone making a similar error?