### PR TITLE
Fix for Next 9.5.2 ("cannot export *") but simplifies Layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,8 @@ The file extension of the template must be one of configured [pageExtensions](ht
 The template, defined in `layouts/docs-page.jsx`, looks like the following:
 
 ```jsx
-export default ({ children, frontMatter }) => {
+// This function must be named otherwise it disables Fast Refresh.
+export default function DocsPage({ children, frontMatter }) {
   // React hooks, for example `useState` or `useEffect`, go here.
   return (
     <div>

--- a/README.md
+++ b/README.md
@@ -160,16 +160,14 @@ The file extension of the template must be one of configured [pageExtensions](ht
 The template, defined in `layouts/docs-page.jsx`, looks like the following:
 
 ```jsx
-export default function Layout(frontMatter) {
-  return ({ children: content }) => {
-    // React hooks, for example `useState` or `useEffect`, go here.
-    return (
-      <div>
-        <h1>{frontMatter.title}</h1>
-        {content}
-      </div>
-    )
-  }
+export default ({ children, frontMatter }) => {
+  // React hooks, for example `useState` or `useEffect`, go here.
+  return (
+    <div>
+      <h1>{frontMatter.title}</h1>
+      {children}
+    </div>
+  )
 }
 ```
 

--- a/__tests__/fixtures/basic/layouts/docs-page.jsx
+++ b/__tests__/fixtures/basic/layouts/docs-page.jsx
@@ -1,17 +1,15 @@
 import { frontMatter as introData } from '../pages/docs/intro.mdx'
 import { frontMatter as advancedData } from '../pages/docs/advanced.mdx'
 
-export default (frontMatter) => {
-  return function docsPageLayout({ children }) {
-    return (
-      <>
-        <p>LAYOUT TEMPLATE</p>
-        <h1>{frontMatter.title}</h1>
-        <p>
-          Other docs: {introData.title}, {advancedData.title}
-        </p>
-        {children}
-      </>
-    )
-  }
+export default function docsPageLayout({ children, frontMatter }) {
+  return (
+    <>
+      <p>LAYOUT TEMPLATE</p>
+      <h1>{frontMatter.title}</h1>
+      <p>
+        Other docs: {introData.title}, {advancedData.title}
+      </p>
+      {children}
+    </>
+  )
 }

--- a/__tests__/fixtures/extend-frontmatter-async/layouts/docs-page.jsx
+++ b/__tests__/fixtures/extend-frontmatter-async/layouts/docs-page.jsx
@@ -1,18 +1,16 @@
 import { frontMatter as introData } from '../pages/docs/intro.mdx'
 import { frontMatter as advancedData } from '../pages/docs/advanced.mdx'
 
-export default (frontMatter) => {
-  return function docsPageLayout({ children }) {
-    return (
-      <>
-        <p>LAYOUT TEMPLATE</p>
-        <h1>{frontMatter.title}</h1>
-        <p>All frontMatter: {JSON.stringify(frontMatter)}</p>
-        <p>
-          Other docs: {introData.title}, {advancedData.title}
-        </p>
-        {children}
-      </>
-    )
-  }
+export default function docsPageLayout({ children, frontMatter }) {
+  return (
+    <>
+      <p>LAYOUT TEMPLATE</p>
+      <h1>{frontMatter.title}</h1>
+      <p>All frontMatter: {JSON.stringify(frontMatter)}</p>
+      <p>
+        Other docs: {introData.title}, {advancedData.title}
+      </p>
+      {children}
+    </>
+  )
 }

--- a/__tests__/fixtures/extend-frontmatter/layouts/docs-page.jsx
+++ b/__tests__/fixtures/extend-frontmatter/layouts/docs-page.jsx
@@ -1,18 +1,16 @@
 import { frontMatter as introData } from '../pages/docs/intro.mdx'
 import { frontMatter as advancedData } from '../pages/docs/advanced.mdx'
 
-export default (frontMatter) => {
-  return function docsPageLayout({ children }) {
-    return (
-      <>
-        <p>LAYOUT TEMPLATE</p>
-        <h1>{frontMatter.title}</h1>
-        <p>All frontMatter: {JSON.stringify(frontMatter)}</p>
-        <p>
-          Other docs: {introData.title}, {advancedData.title}
-        </p>
-        {children}
-      </>
-    )
-  }
+export default function docsPageLayout({ children, frontMatter }) {
+  return (
+    <>
+      <p>LAYOUT TEMPLATE</p>
+      <h1>{frontMatter.title}</h1>
+      <p>All frontMatter: {JSON.stringify(frontMatter)}</p>
+      <p>
+        Other docs: {introData.title}, {advancedData.title}
+      </p>
+      {children}
+    </>
+  )
 }

--- a/__tests__/fixtures/layout-exports-ssg/layouts/docs-page.jsx
+++ b/__tests__/fixtures/layout-exports-ssg/layouts/docs-page.jsx
@@ -4,14 +4,12 @@ export async function getStaticProps() {
   return { props: {} }
 }
 
-export default function Page(frontMatter) {
-  return function docsPageLayout({ children }) {
-    return (
-      <>
-        <p>LAYOUT TEMPLATE</p>
-        <h1>{frontMatter.title}</h1>
-        {children}
-      </>
-    )
-  }
+export default function docsPageLayout({ children, frontMatter }) {
+  return (
+    <>
+      <p>LAYOUT TEMPLATE</p>
+      <h1>{frontMatter.title}</h1>
+      {children}
+    </>
+  )
 }

--- a/__tests__/fixtures/layouts-path/snargles/index.jsx
+++ b/__tests__/fixtures/layouts-path/snargles/index.jsx
@@ -1,17 +1,15 @@
 import { frontMatter as introData } from '../pages/docs/intro.mdx'
 import { frontMatter as advancedData } from '../pages/docs/advanced.mdx'
 
-export default (frontMatter) => {
-  return function docsPageLayout({ children }) {
-    return (
-      <>
-        <p>LAYOUT TEMPLATE</p>
-        <h1>{frontMatter.title}</h1>
-        <p>
-          Other docs: {introData.title}, {advancedData.title}
-        </p>
-        {children}
-      </>
-    )
-  }
+export default function docsPageLayout({ children, frontMatter }) {
+  return (
+    <>
+      <p>LAYOUT TEMPLATE</p>
+      <h1>{frontMatter.title}</h1>
+      <p>
+        Other docs: {introData.title}, {advancedData.title}
+      </p>
+      {children}
+    </>
+  )
 }

--- a/__tests__/fixtures/on-content/layouts/docs-page.jsx
+++ b/__tests__/fixtures/on-content/layouts/docs-page.jsx
@@ -1,5 +1,3 @@
-export default function Page() {
-  return function docsPageLayout({ children }) {
-    return <>{children}</>
-  }
+export default function docsPageLayout({ children }) {
+  return <>{children}</>
 }

--- a/__tests__/fixtures/scan-mdx-content/layouts/docs-page.jsx
+++ b/__tests__/fixtures/scan-mdx-content/layouts/docs-page.jsx
@@ -1,30 +1,29 @@
 import { frontMatter as introData } from '../pages/docs/intro.mdx'
 import { frontMatter as advancedData } from '../pages/docs/advanced.mdx'
-export default (frontMatter) => {
+
+export default function docsPageLayout({ children, frontMatter }) {
   const __scans = frontMatter.__scans
-  return function docsPageLayout({ children }) {
-    return (
-      <>
-        {/* Similar to adding a script to document <head/> we load a font stylesheet here vs. running arbitrary JS */}
-        {__scans.hasSnargles && (
-          <link
-            href="https://fonts.googleapis.com/css?family=Press+Start+2P"
-            rel="stylesheet"
-          />
-        )}
+  return (
+    <>
+      {/* Similar to adding a script to document <head/> we load a font stylesheet here vs. running arbitrary JS */}
+      {__scans.hasSnargles && (
+        <link
+          href="https://fonts.googleapis.com/css?family=Press+Start+2P"
+          rel="stylesheet"
+        />
+      )}
 
-        <h1 style={{ fontFamily: "'Press Start 2P'" }}>{frontMatter.title}</h1>
-        <h2 style={{ fontFamily: "'Press Start 2P'" }}>
-          Should render in 8-bit font because...
-        </h2>
-        {__scans.hasSnargles && <h1>We found snargles</h1>}
+      <h1 style={{ fontFamily: "'Press Start 2P'" }}>{frontMatter.title}</h1>
+      <h2 style={{ fontFamily: "'Press Start 2P'" }}>
+        Should render in 8-bit font because...
+      </h2>
+      {__scans.hasSnargles && <h1>We found snargles</h1>}
 
-        {__scans.snarglesName && <h1>{__scans.snarglesName}</h1>}
-        <p>
-          Other docs: {introData.title}, {advancedData.title}
-        </p>
-        {children}
-      </>
-    )
-  }
+      {__scans.snarglesName && <h1>{__scans.snarglesName}</h1>}
+      <p>
+        Other docs: {introData.title}, {advancedData.title}
+      </p>
+      {children}
+    </>
+  )
 }

--- a/loader.js
+++ b/loader.js
@@ -129,11 +129,13 @@ async function processLayout(
     })
   }
 
-  // Import the layout, export the layout-wrapped content, pass front matter into layout
-  return `import layout from '${normalizeToUnixPath(layoutPath)}'
+  // Import the layout, and apply to content
+  // MDX will pass all module exports as props to the default export
+  return `import Layout from '${normalizeToUnixPath(layoutPath)}'
 
-export * from '${normalizeToUnixPath(layoutPath)}'
-export default layout(${stringifyObject(mergedFrontMatter)})
+export default Layout
+
+export const frontMatter = ${stringifyObject(mergedFrontMatter)}
 
 ${content}
 `


### PR DESCRIPTION
(partially) Fixes #74 

Next 9.5.2 introduced a new check that stops pages from ["re-exporting all exports from next pages"](https://github.com/vercel/next.js/pull/14325). Unfortunately this causes the loader to break down since it was use this.

## Change to Layouts

I also encountered this issue on `mdx-js/mdx` (core module): [Pass exports to layout component](https://github.com/mdx-js/mdx/issues/378). It seems like mdx layouts should automatically receive props for any of the exports within their document. Rather than have the Layout template wrap and receive front matter separately I simply include it as an export within the page. A benefit to this approach is that other `exports` without our mdx template will now also be available to the layout template (not just the `frontMatter` data itself).

Because this changes how the default layouts worked, I had to update each of the tests. HOWEVER, I like this change because I think it makes Layouts more like default next pages (that will render whatever component is "exported default" without any extra wrapper logic).

**This is probably a breaking change.**

## Caveats

This bugfix does not currently address data fetching from layouts. Next.js default page api allows for data fetching via special namedExports for `getStaticProps` (and others). When the page is generated ahead of time, next uses these callbacks to pass dynamic data at build/compile/serve time (as additional props depending on the return values of these methods). 

On the root issue there are notes about how previously the `export * from` was designed to intentionally [pass some of these additional values](https://github.com/hashicorp/next-mdx-enhanced/issues/74#issuecomment-673608338), and unfortunately I couldn't find a crafty way to do this in the loader when the module may or may not include these exports. (If you have ideas or improvements, please let me know.)

