### PR TITLE
Miscellaneous fixes: hot reloading (#43) and potentially #61 (Can't resolve '...json')

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,9 +91,16 @@ module.exports = (pluginOptions = {}) => (nextConfig = {}) => {
   })
 }
 
-// Given an array of absolute file paths, write out the front matter to a json file
-async function extractFrontMatter(pluginOptions, files, root) {
+// Given an array of file paths, write out the front matter to a json file
+async function extractFrontMatter(
+  pluginOptions,
+  absoluteOrRelativeFilePaths,
+  root
+) {
   debug('start: read all mdx files')
+  const files = absoluteOrRelativeFilePaths.map((filePath) =>
+    path.isAbsolute(filePath) ? filePath : path.resolve(root, filePath)
+  )
   const fileContents = await Promise.all(
     files.map((f) => fs.readFile(f, 'utf8'))
   )
@@ -137,7 +144,7 @@ async function extractFrontMatter(pluginOptions, files, root) {
   debug('start: write data files')
   return Promise.all(
     frontMatter.map((content, idx) => {
-      fs.writeFile(fmPaths[idx], JSON.stringify(content))
+      return fs.writeFile(fmPaths[idx], JSON.stringify(content))
     })
   ).then(() => {
     debug('finish: write data files')


### PR DESCRIPTION
1/ Hot reloading (#43):

For some reason `extractFrontMatter()` can receive relative paths on file updates. Let's say you start with 2 mdx files: `A.mdx` and `B.mdx`. When you update `B.mdx` while the dev server is running, it can generate a 3rd json file under `.mdx-data` since the new md5 sum is based on a relative file path. This breaks hot/live reloading (because I think the new json file doesn't really get picked up by Next) and you have to restart the dev server to apply changes.

By updating `extractFrontMatter()` to use absolute paths, updates always write to the corresponding json file. I verified locally that the number of json files always === the number of mdx files being processed. Jest tests also pass locally.


2/ Potentially #61 (Can't resolve '...json'):
Not 100% sure if it's the right fix but I noticed that the `fs.writeFile()` promises didn't get awaited. Updating that seems to fix the issue locally for me.